### PR TITLE
Fix offset adjusting

### DIFF
--- a/firmware/src/TTLReader.cpp
+++ b/firmware/src/TTLReader.cpp
@@ -315,12 +315,14 @@ void TTLReader::changePxClk(bool Increase, bool SmallStep) {
   DBG_PRINT(std::cout << "\n-----------\n";)
   DBG_PRINT(std::cout << "Pixel Clock Before=" << PixelClock;)
   // WARNING: This should match the sampling offsets in the PIO files!!!
-  static constexpr const uint32_t SamplingOffsetMod = 16 + 1;
+  // Only EGA has 16 offsets, others - 4!
+  const uint32_t SamplingOffsetMod = ((TimingsTTL.Mode == TTL::EGA) ?
+                                       17 : 5); // 16+1 : 4+1
   if (Increase) {
     DBG_PRINT(std::cout << " ++ ";)
     if (SmallStep) {
       SamplingOffset = (SamplingOffset + 1) % SamplingOffsetMod;
-      if (SamplingOffset % 5 == 0)
+      if (SamplingOffset == 0)
         PixelClock += PXL_CLK_SMALL_STEP;
     } else {
       PixelClock += PXL_CLK_STEP;
@@ -330,7 +332,7 @@ void TTLReader::changePxClk(bool Increase, bool SmallStep) {
     if (SmallStep) {
       SamplingOffset =
           SamplingOffset == 0 ? (SamplingOffsetMod - 1) : SamplingOffset - 1;
-      if (SamplingOffset % SamplingOffsetMod == 0)
+      if (SamplingOffset == (SamplingOffsetMod - 1))
         PixelClock -= PXL_CLK_SMALL_STEP;
     } else {
       PixelClock -= PXL_CLK_STEP;


### PR DESCRIPTION
There are some issues with offset adjusting.

Firstly, I can't normally switch between offsets because there is a frequency increment after each 5 offsets (but they were increased to 16). Also, decreasing from offset 1 to 0 triggers a frequency decrement; it must be triggered between 0 and 16, as I understand.
And since there are 16 offsets, but only for EGA, trying to adjust CGA (MDA too, I guess) hangs Blaster when it tries to use 5-16 offsets, since they're absent for this mode, so it requires a detection to limit the range.

I'm not so familiar with C++ and Pico (only some Arduino C experience), but it looks like my small fix works.

Before:
https://youtu.be/yLLoYmnrsSI

After:
https://youtu.be/F3BmzwIsFWI